### PR TITLE
Fix minmax logic to not allow the 2 values to be equal

### DIFF
--- a/main.js
+++ b/main.js
@@ -174,7 +174,7 @@ function checkMinMaxInputs(inputsToCheck,button){
     if (inputsToCheck[i].value.length == 0) {
       canSubmit = false;
     }
-    if (inputsToCheck[1].value < inputsToCheck[0].value && inputsToCheck[1].value.length > 0) {
+    if (inputsToCheck[1].value <= inputsToCheck[0].value && inputsToCheck[1].value.length > 0) {
       canSubmit = false;
       minMaxError.classList.add("error-box-show");
     } else {


### PR DESCRIPTION
Just added <= in the minmax function instead of <.